### PR TITLE
Fix Swift Package build for PAGE branch

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Charts",
     platforms: [
-          .iOS(.v9),
+          .iOS(.v12),
           .tvOS(.v9),
           .macOS(.v10_11),
     ],

--- a/Source/Charts/Data/Implementations/Standard/StockTrendLineChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/StockTrendLineChartDataSet.swift
@@ -9,6 +9,7 @@
 
 import Foundation
 import CoreGraphics
+import UIKit
 
 /// 股價走勢圖專用DataSet
 public class StockTrendLineChartDataSet: LineChartDataSet {

--- a/Source/Charts/Renderers/DrawChartRenderer.swift
+++ b/Source/Charts/Renderers/DrawChartRenderer.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import CoreGraphics
+import UIKit
 
 public class DrawChartRenderer: BarLineScatterCandleBubbleRenderer {
     

--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -11,6 +11,7 @@
 
 import Foundation
 import CoreGraphics
+import UIKit
 
 open class LineChartRenderer: LineRadarRenderer
 {


### PR DESCRIPTION
## Summary
- Raise SwiftPM iOS platform to iOS 12 for the PAGE branch target compatibility.
- Add explicit UIKit/CoreGraphics imports required by SwiftPM builds.

## Validation
- Built an external SwiftPM consumer against this branch successfully.
- Log: /tmp/cmmobile-charts-page-consumer-spm-build-1782381500.log

## Context
- This is required before CMFinancialStatementKit can ship SwiftPM support with a versioned Charts dependency.